### PR TITLE
Add support for obsolete kinds of function declarations

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -184,7 +184,7 @@ function convert_type(cursor::LibClang.CXCursor, typ::LibClang.CXType, indent::I
 	elseif typ.kind == LibClang.CXType_Pointer
 		((pre, t, post), comments) = convert_type(cursor, LibClang.clang_getPointeeType(typ), indent)
 		(pre, post) = ("𝐣𝐥.Ptr{"*pre, post*"}")
-	elseif typ.kind in (LibClang.CXType_Unexposed, LibClang.CXType_FunctionProto)
+	elseif typ.kind in (LibClang.CXType_Unexposed, LibClang.CXType_FunctionProto, LibClang.CXType_FunctionNoProto)
 		((pre, t, post), comments) = convert_type(cursor, LibClang.clang_getResultType(typ), indent)
 		
 		num = LibClang.clang_getNumArgTypes(typ)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -461,6 +461,11 @@ using CBindingGen
 				}), s::𝐣𝐥.Ptr{𝐣𝐥.@cstruct SG1})::_)::𝐣𝐥.@cstruct SG1 {
 					i::𝐣𝐥.Cint
 				}""", "SG1", "N1", "N2", "f12", "f13", "g8")
+			
+			check("""
+				𝐣𝐥.@cstruct S38 {
+					f::𝐣𝐥.Ptr{𝐣𝐥.Cfunction{𝐣𝐥.Cvoid, 𝐣𝐥.Tuple{𝐣𝐥.Vararg}, 𝐣𝐥.CDECL}}
+				}""", "S38")
 		end
 		
 		@testset "pre-processor directives" begin

--- a/test/test.h
+++ b/test/test.h
@@ -299,6 +299,10 @@ struct SG1 {
 
 static void f14(void);
 
+struct S38 {
+	void (*f)();
+};
+
 
 #define DEFINE_CHAR ('\'')
 #define DEFINE_STRING ("\"")


### PR DESCRIPTION
i.e. `void func()`

https://stackoverflow.com/questions/41803937/func-vs-funcvoid-in-c99